### PR TITLE
doc: add link to « Kocal/vue-web-extension » repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ yarn test
   - Dedicated extension pages
   - Options Pages
   - Content scripts
-- More configurability in scaffolding, like Kocal/vue-web-extension does
+- More configurability in scaffolding, like [Kocal/vue-web-extension](https://github.com/Kocal/vue-web-extension) does
 - A preset
 - Key Generation
 


### PR DESCRIPTION
`Kocal/vue-web-extension` appears three times in `README.md`, but only two occurences are links, the other one is text only.

I thought it was a good thing to fix it.