### PR TITLE
Fix missing chunks in background and content scripts when in production mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = (api, options) => {
   const hasKeyFile = fs.existsSync(keyFile)
 
   api.chainWebpack((webpackConfig) => {
-    const config = webpackConfig.entryPoints.delete('app').end()
+    webpackConfig.entryPoints.delete('app')
     const entry = {}
     if (pluginOptions.components.background) {
       entry['background'] = [api.resolve(componentOptions.background.entry)]
@@ -37,7 +37,8 @@ module.exports = (api, options) => {
         entry[name] = paths.map(path => api.resolve(path))
       }
     }
-    config.merge({entry})
+    webpackConfig.merge({entry})
+    webpackConfig.optimization.delete('splitChunks')
   })
 
   api.configureWebpack((webpackConfig) => {


### PR DESCRIPTION
When in production mode, Vue CLI splits chunks into separate files. Since the background and content scripts are single js files and don't have corresponding HTML files, they shouldn't be split up into separate chunks.

This pull request is made to be compatible with and is based on my other pull request: #14