### PR TITLE
Disable hashed URL params in chunk filenames

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = (api, options) => {
 
   api.configureWebpack((webpackConfig) => {
     webpackConfig.output.filename = '[name].js'
-    webpackConfig.output.chunkFilename = 'js/[id].[name].js?[hash:8]'
+    webpackConfig.output.chunkFilename = 'js/[id].[name].js'
     webpackConfig.node.global = false
 
     if (isProduction) {


### PR DESCRIPTION
The hashes were causing issues in the zipped output. Since the hashes were only being added to the zipped output, they have been removed entirely.