### PR TITLE
Make CopyWebpackPlugin pattern an array

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ module.exports = (api, options) => {
       }
     }
 
-    webpackConfig.plugins.push(new CopyWebpackPlugin({
+    webpackConfig.plugins.push(new CopyWebpackPlugin([{
       from: './src/manifest.json',
       to: 'manifest.json',
       transform: (content) => {
@@ -102,7 +102,7 @@ module.exports = (api, options) => {
           }
         })
       }
-    }))
+    }]))
 
     if (isProduction) {
       webpackConfig.plugins.push(new ZipPlugin({


### PR DESCRIPTION
I shamefully forgot to test PR #14 after committing 3350582860cc7c462013f5918dade18d4f549092 and thus missed that it incorrectly passed an object to CopyWebpackPlugin instead of an array. This PR fixes that mistake.