### PR TITLE
content_security_policy is not overwritten by default anymore.

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ module.exports = (api, options) => {
             return resolve(JSON.stringify(jsonContent, null, 2))
           }
 
-          jsonContent.content_security_policy = "script-src 'self' 'unsafe-eval'; object-src 'self'"
+          jsonContent.content_security_policy = jsonContent.content_security_policy || "script-src 'self' 'unsafe-eval'; object-src 'self'"
 
           try {
             fs.statSync(keyFile)


### PR DESCRIPTION
Hi @adambullmer 

I was wondering why my custom CSP was not being set in the distributed manifest.json.

All that is inside this change is that it will now use the user set content_security_policy before it overwrites it to the default of: "script-src 'self' 'unsafe-eval'; object-src 'self'"