### PR TITLE
Add a new plugin option to modify the outputted manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,22 @@ module.exports = {
 
   Currently, the only supported keys are `version` and `description`.
 
+- **manifestTransformer**
+  - Type: `Function`
+  
+  Function to modify the manifest JSON outputted by this plugin.
+
+  An example use case is adding or removing permissions depending on which browser is being targeted.
+
+  ```js
+  manifestTransformer: (manifest) => {
+    if (process.env.BROWSER === 'chrome') {
+      manifest.permissions.push('pageCapture');
+    }
+    return manifest;
+  }
+  ```
+
 - **modesToZip**
   - Type: `Array<string>`
   - Default: `['production']`

--- a/index.js
+++ b/index.js
@@ -9,13 +9,22 @@ const defaultOptions = {
   components: {},
   componentOptions: {},
   manifestSync: ['version'],
-  modesToZip: ['production']
+  modesToZip: ['production'],
+  manifestTransformer: null
 }
 const performanceAssetFilterList = [
   (file) => !(/\.map$/.test(file)),
   (file) => !file.endsWith('.zip'),
   (file) => !(/^icons\//.test(file))
 ]
+
+function getManifestJsonString(pluginOptions, jsonContent) {
+  if (pluginOptions.manifestTransformer) {
+    const jsonContentCopy = Object.assign({}, jsonContent);
+    jsonContent = pluginOptions.manifestTransformer(jsonContentCopy)
+  }
+  return JSON.stringify(jsonContent, null, 2)
+}
 
 module.exports = (api, options) => {
   const appRootPath = api.getCwd()
@@ -91,7 +100,7 @@ module.exports = (api, options) => {
           }
 
           if (isProduction) {
-            return resolve(JSON.stringify(jsonContent, null, 2))
+            return resolve(getManifestJsonString(pluginOptions, jsonContent))
           }
 
           jsonContent.content_security_policy = jsonContent.content_security_policy || "script-src 'self' 'unsafe-eval'; object-src 'self'"
@@ -106,11 +115,11 @@ module.exports = (api, options) => {
               }
 
               jsonContent.key = stdout
-              resolve(JSON.stringify(jsonContent, null, 2))
+              resolve(getManifestJsonString(pluginOptions, jsonContent))
             })
           } catch (error) {
             logger.warn('No key.pem file found. This is fine for dev, however you may have problems publishing without one')
-            resolve(JSON.stringify(jsonContent, null, 2))
+            resolve(getManifestJsonString(pluginOptions, jsonContent))
           }
         })
       }


### PR DESCRIPTION
The new plugin option is a function which is passed the manifest created by this plugin and returns a modified manifest.

An example use case is adding or removing permissions depending on which browser is being targeted.