### PR TITLE
Fix .html files not being used

### DIFF
--- a/generator/index.js
+++ b/generator/index.js
@@ -68,6 +68,7 @@ module.exports = (api, _options) => {
 
     pkg.vue.pages['popup/popup'] = {
       entry: 'src/popup/popup.js',
+      template: 'src/popup/popup.html',
       title: 'Popup'
     }
   }
@@ -77,6 +78,7 @@ module.exports = (api, _options) => {
 
     pkg.vue.pages['options/options'] = {
       entry: 'src/options/options.js',
+      template: 'src/options/options.html',
       title: 'Options'
     }
   }
@@ -86,6 +88,7 @@ module.exports = (api, _options) => {
 
     pkg.vue.pages['override/override'] = {
       entry: 'src/override/override.js',
+      template: 'src/override/override.html',
       title: 'Override'
     }
   }
@@ -96,6 +99,7 @@ module.exports = (api, _options) => {
 
     pkg.vue.pages['standalone/standalone'] = {
       entry: 'src/standalone/standalone.js',
+      template: 'src/standalone/standalone.html',
       filename: 'app.html',
       title: name
     }


### PR DESCRIPTION
Without the `template` option, the html files in dist are being auto-generated, and the html files in src ignored.