### PR TITLE
Support config of webpack-extension-reloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ module.exports = {
 
   See [Component options](#component-options).
 
+- **extensionReloaderOptions**
+
+  - Type: `Object.<string, Object>`
+
+  See available options in [webpack-extension-reloader](https://github.com/rubenspgcavalcante/webpack-extension-reloader#how-to-use).
+
 - **manifestSync**
 
   - Type: `Array<string>`

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const manifestTransformer = require('./lib/manifest')
 const defaultOptions = {
   components: {},
   componentOptions: {},
+  extensionReloaderOptions: {},
   manifestSync: ['version'],
   modesToZip: ['production'],
   manifestTransformer: null
@@ -24,6 +25,7 @@ module.exports = (api, options) => {
     ? Object.assign(defaultOptions, options.pluginOptions.browserExtension)
     : defaultOptions
   const componentOptions = pluginOptions.componentOptions
+  const extensionReloaderOptions = pluginOptions.extensionReloaderOptions
   const packageJson = require(api.resolve('package.json'))
   const isProduction = api.service.mode === 'production'
   const keyFile = api.resolve('key.pem')
@@ -105,7 +107,7 @@ module.exports = (api, options) => {
     // configure webpack-extension-reloader for automatic reloading of extension when content and background scripts change (not HMR)
     // enabled only when webpack mode === 'development'
     if (!isProduction) {
-      webpackConfig.plugin('extension-reloader').use(ExtensionReloader, [{ entries }])
+      webpackConfig.plugin('extension-reloader').use(ExtensionReloader, [{ entries, ...extensionReloaderOptions }])
     }
 
     webpackConfig.plugin('copy').tap((args) => {


### PR DESCRIPTION
Example usage:

```javascript 
pluginOptions: {
  browserExtension: {
    extensionReloaderOptions: {
      reloadPage: false,
      entries: {
        background: 'background',
        contentScript: ['content_scripts/content'],
      },
    },
  },
}
```



The same can be achieved with `chainWebpack`, but it requires conditionals and looks more complicated. Example:
```javascript
if (process.env.NODE_ENV !== 'production') {
  config.plugin('extension-reloader').tap(([options]) => {
    return [
      {
        ...options,
        reloadPage: false,
        entries: {
          background: 'background',
          contentScript: ['content_scripts/content'],
        },
      },
    ]
  })
}

```

It seems like it should be the responsibility of this plugin to provide a way to customize the options.