### PR TITLE
Fix optimization

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,9 +118,13 @@ module.exports = (api, options) => {
 
   api.configureWebpack((webpackConfig) => {
     const omitUserScripts = ({ name }) => !userScripts.includes(name)
-    if (isProduction) {
-      webpackConfig.optimization.splitChunks.cacheGroups.vendors.chunks = omitUserScripts
-      webpackConfig.optimization.splitChunks.cacheGroups.common.chunks = omitUserScripts
+    if (webpackConfig.optimization && webpackConfig.optimization.splitChunks && webpackConfig.optimization.splitChunks.cacheGroups) {
+      if (webpackConfig.optimization.splitChunks.cacheGroups.vendors) {
+        webpackConfig.optimization.splitChunks.cacheGroups.vendors.chunks = omitUserScripts
+      }
+      if (webpackConfig.optimization.splitChunks.cacheGroups.common) {
+        webpackConfig.optimization.splitChunks.cacheGroups.common.chunks = omitUserScripts
+      }
     }
   })
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-browser-extension",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "Browser extension development plugin for vue-cli 3.0",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Looks to be that vue's base configs have started to include some optimizations in development modes as well. This PR expands on the detection and attempts to keep it without error in case any more surprises come up. These user scripts (background and content scripts) cannot load multiple files to take advantage of codesplitting, so these need to be removed from optimizations always.