### PR TITLE
Replace modesToZip with `NODE_ENV=production`

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,10 +154,7 @@ module.exports = {
 
 - **modesToZip**
 
-  - Type: `Array<string>`
-  - Default: `['production']`
-
-  Array containing names of mode in which zipping up will trigger after build.
+  Deprecated. Any mode will be zipped to the artifacts dir, when `NODE_ENV=production` (the default in the normal `yarn build`). For more information on how to set `NODE_ENV=production` in other modes see [Vue CLI docs – Example Staging Mode](https://cli.vuejs.org/guide/mode-and-env.html#example-staging-mode)
 
 - **artifactsDir**
 

--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@ const defaultOptions = {
   componentOptions: {},
   extensionReloaderOptions: {},
   manifestSync: ['version'],
-  modesToZip: ['production'],
   manifestTransformer: null
 }
 const performanceAssetFilterList = [
@@ -27,7 +26,7 @@ module.exports = (api, options) => {
   const componentOptions = pluginOptions.componentOptions
   const extensionReloaderOptions = pluginOptions.extensionReloaderOptions
   const packageJson = require(api.resolve('package.json'))
-  const isProduction = api.service.mode === 'production'
+  const isProduction = process.env.NODE_ENV === 'production'
   const keyFile = api.resolve('key.pem')
   const hasKeyFile = keyExists(keyFile)
   const contentScriptEntries = Object.keys((componentOptions.contentScripts || {}).entries || {})
@@ -95,7 +94,7 @@ module.exports = (api, options) => {
       }
     }
 
-    if (pluginOptions.modesToZip.includes(api.service.mode)) {
+    if (isProduction) {
       webpackConfig.plugin('zip-browser-extension').use(ZipPlugin, [
         {
           path: api.resolve(pluginOptions.artifactsDir || 'artifacts'),


### PR DESCRIPTION
This is a breaking change, but modesToZip is not working for me anyway,
so I wonder if anyone is actually using it successfully.

https://cli.vuejs.org/guide/mode-and-env.html#example-staging-mode

Close #70
Fix #71