### PR TITLE
chore(readme): update text about Kocal/vue-web-extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Browser extension development plugin for vue-cli 3.x
 
 ## What does it do?
 
-This is intended to be a vue-cli@3.x replacement for [https://github.com/Kocal/vue-web-extension](https://github.com/Kocal/vue-web-extension).
+This is intended to be a vue-cli@3.x replacement for [Kocal/vue-web-extension `v1`](https://github.com/Kocal/vue-web-extension/tree/v1) (now, [Kocal/vue-web-extension](https://github.com/Kocal/vue-web-extension) is a preset using this plugin).
 
 This plugin changes the `serve` command for your vue applications.
 This new command is only for running a livereload server while testing out your browser extension.


### PR DESCRIPTION
Hi, It has been a long time! :wave: 

These last days, I've transformed Kocal/vue-web-extension from a Vue CLI 2 boilerplate to a Vue CLI 3+ preset (which include this plugin), see https://github.com/Kocal/vue-web-extension/releases/tag/v2.0.0.

I thought it would be nice to update the warning message on the README.

What do you think?
Thanks! :)