### PR TITLE
fix(csp): define global as 'window' to prevent CSP issues

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,6 +120,13 @@ module.exports = (api, options) => {
         return args
       })
     }
+
+    webpackConfig.plugin('define').tap(args => [
+      {
+        ...args[0],
+        global: 'window'
+      },
+    ])
   })
 
   api.configureWebpack((webpackConfig) => {


### PR DESCRIPTION
Hey :wave: 

@t-miller faced an issue on https://github.com/Kocal/vue-web-extension/issues/658, with the usage of `Function()` and `eval()` in the dist code, complying with Mozilla' CSP when uploading the extension on their web store.

I fixed the same issue in a previous version of my preset (see https://github.com/Kocal/vue-web-extension/pull/398), and so I'm applying it here to impact more people.

I used `.tap()` to update `DefinePlugin` arguments, which is always configured by Vue-CLI. 

Here is the output of `vue-cli-service inspect`: 
![image](https://user-images.githubusercontent.com/2103975/105615449-0c3ffc00-5dd1-11eb-837a-7bc6d6927df1.png)


