### PR TITLE
Handling of key.pem when path contains spaces

### DIFF
--- a/lib/signing-key.js
+++ b/lib/signing-key.js
@@ -7,7 +7,7 @@ exports.generateKey = () => execSync('openssl genrsa 2048 | openssl pkcs8 -topk8
 
 exports.hashKey = (keyFile) =>
   new Promise((resolve, reject) => {
-    exec(`openssl rsa -in ${keyFile} -pubout -outform DER | openssl base64 -A`, (error, stdout) => {
+    exec(`openssl rsa -in "${keyFile}" -pubout -outform DER | openssl base64 -A`, (error, stdout) => {
       if (error) {
         // node couldn't execute the command
         return reject(error)


### PR DESCRIPTION
When the path to key.pem contains spaces, the hash does not get generated during development and therefore `key` in manisfest.json goes as a blank string and chrome does not allow loading the unpacked extension. Fixing this issue.