### PR TITLE
Support custom artifact filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,36 @@ module.exports = {
 
   Directory where the zipped browser extension should get created.
 
+- **artifactFilename**
+
+  - Type: `Function`
+  - Default: ``({name, version, mode}) => `${name}-v${version}-${mode}.zip` ``
+
+  Optional function to generate a custom artifact filename. Useful for naming builds for different browsers.
+
+  The function takes a single object parameter containing:
+  - `name` - Name from `package.json`
+  - `version` - Version from `package.json`
+  - `mode` - Vue CLI mode such as 'production'
+  
+  For example,
+
+  ```js
+  // vue.config.js
+  module.exports = {
+    pluginOptions: {
+      browserExtension: {
+        artifactFilename: ({ name, version, mode }) => {
+          if (mode === 'production') {
+            return `${name}-v${version}-${process.env.BROWSER}.zip`;
+          }
+          return `${name}-v${version}-${process.env.BROWSER}-${mode}.zip`;
+        },
+      },
+    },
+  };
+  ```
+
 ### Component options
 
 Some browser extension components have additional options which can be set as follows:

--- a/index.js
+++ b/index.js
@@ -100,20 +100,20 @@ module.exports = (api, options) => {
     }
 
     if (isProduction) {
-      let filename;
+      let filename
       if (pluginOptions.artifactFilename) {
         filename = pluginOptions.artifactFilename({
           name: packageJson.name,
           version: packageJson.version,
-          mode: api.service.mode,
-        });
+          mode: api.service.mode
+        })
       } else {
         filename = `${packageJson.name}-v${packageJson.version}-${api.service.mode}.zip`
       }
       webpackConfig.plugin('zip-browser-extension').use(ZipPlugin, [
         {
           path: api.resolve(pluginOptions.artifactsDir || 'artifacts'),
-          filename: filename,
+          filename: filename
         }
       ])
     }

--- a/index.js
+++ b/index.js
@@ -100,10 +100,20 @@ module.exports = (api, options) => {
     }
 
     if (isProduction) {
+      let filename;
+      if (pluginOptions.artifactFilename) {
+        filename = pluginOptions.artifactFilename({
+          name: packageJson.name,
+          version: packageJson.version,
+          mode: api.service.mode,
+        });
+      } else {
+        filename = `${packageJson.name}-v${packageJson.version}-${api.service.mode}.zip`
+      }
       webpackConfig.plugin('zip-browser-extension').use(ZipPlugin, [
         {
           path: api.resolve(pluginOptions.artifactsDir || 'artifacts'),
-          filename: `${packageJson.name}-v${packageJson.version}-${api.service.mode}.zip`
+          filename: filename,
         }
       ])
     }


### PR DESCRIPTION
Useful for naming builds for different browsers.