### PR TITLE
Add support for manifest-v3 Content Security Policy

### DIFF
--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -18,26 +18,47 @@ function syncManifestWithPackageJson ({ manifestSync }, packageJson, manifest) {
   })
 }
 
+function getDefaultManifestAttributes (manifest, production) {
+  switch (manifest.manifest_version) {
+    case 2:
+      // Set reasonable defaults for manifest V2:
+      return {
+        content_security_policy: "script-src 'self'" + (production ? '' : " 'unsafe-eval'") + "; object-src 'self'"
+      }
+
+    case 3:
+      // Set reasonable defaults for manifest V3:
+      return {
+        content_security_policy: {
+          extension_pages: "script-src 'self'; object-src 'self'",
+          sandbox: "script-src 'self'" + (production ? '' : " 'unsafe-eval'") + "; object-src 'self'"
+        }
+      }
+
+    default:
+      // Issue a warning if an unsupported manifest version is detected:
+      logger.warn(`Unsupported manifest version '${manifest.manifest_version}'; no manifest defaults will be applied`)
+      return {}
+  }
+}
+
 module.exports = (api, pluginOptions, packageJson) => async (content) => {
-  const manifest = JSON.parse(content)
+  const userManifest = JSON.parse(content)
   const keyFile = api.resolve('key.pem')
   const hasKeyFile = keyExists(keyFile)
   const isProduction = api.service.mode === 'production'
 
-  syncManifestWithPackageJson(pluginOptions, packageJson, manifest)
+  syncManifestWithPackageJson(pluginOptions, packageJson, userManifest)
 
-  manifest.content_security_policy =
-    manifest.content_security_policy || "script-src 'self' 'unsafe-eval'; object-src 'self'"
+  // Apply manifest defaults:
+  const manifestDefaults = getDefaultManifestAttributes(userManifest, isProduction)
+  const manifest = Object.assign(manifestDefaults, userManifest)
 
   // validate manifest
 
   // If building for production (going to web store) abort early.
   // The browser extension store will hash your signing key and apply CSP policies.
   if (isProduction) {
-    manifest.content_security_policy = manifest.content_security_policy.replace(/'unsafe-eval'/, '')
-
-    // validate minimum options
-
     return getManifestJsonString(pluginOptions, manifest)
   }
 


### PR DESCRIPTION
See #130 for discussion of the underlying issue.
Given that this PR implements new functionality necessary for supporting manifest-v3 without detracting from any existing functionality, I feel it makes sense to include this in version 0.26.

## Description

The new function to compute defaults for the manifest file should be
able to maintain the old defaults for manifest-v2 exactly as they were,
while also allowing manifest-v3 compatible CSP objects.

The function will also emit a warning when an unsupported manifest
version is encountered, but for the sake of future-proofing, no errors
are emitted, and the compiler process is not halted.

## Checks
- [X] `yarn run eslint .`
- [X] `yarn test`

